### PR TITLE
Stash compilation error

### DIFF
--- a/test/test__cache.ml
+++ b/test/test__cache.ml
@@ -39,7 +39,7 @@ let%expect_test "override" =
   (* An empty interface has no cache. *)
   show_cache (Provider.Interface.make []);
   [%expect {| None |}];
-  let (Provider.T { t = _; interface }) = num_printer in
+  let (Provider.T (type a) { t = (_ : a); interface }) = num_printer in
   let int_printer_lookup () =
     (fun (type a) (interface : (a, _) Provider.Interface.t) ->
       ignore


### PR DESCRIPTION
I don't understand the following error yet, given that I bind the type a by a type constraint on the field [t].

---
```pre
File "test/test__cache.ml", line 42, characters 27-53:
42 |   let (Provider.T (type a) { t = (_ : a); interface }) = num_printer in
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Existential types introduced in a constructor pattern
       must be bound by a type constraint on the argument.
```