### PR TITLE
Reduce deps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+## 0.0.6 (unreleased)
+
+### Changed
+
+- Reduce `provider` package dependencies - reduce from `base` to `sexplib0`.
+
+### Fixed
+
+- Make sure to select the right most implementation in case of overrides, as per specification.
+
+### Removed
+
+- Removed `Trait.Uid.Comparable.S` as this requires `Base`. Make it compatible with `Comparable.Make (Trait.Uid)` and add tests for this use case.
+
 ## 0.0.5 (2024-07-26)
 
 ### Added

--- a/dune-project
+++ b/dune-project
@@ -22,10 +22,6 @@
  (depends
   (ocaml
    (>= 5.2))
-  (base
-   (and
-    (>= v0.17)
-    (< v0.18)))
   (bisect_ppx
    (and
     :dev

--- a/dune-project
+++ b/dune-project
@@ -30,29 +30,15 @@
    (and
     :dev
     (>= 2.8.3)))
-  (ppx_compare
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_hash
-   (and
-    (>= v0.17)
-    (< v0.18)))
   (ppx_js_style
    (and
     :dev
     (>= v0.17)
     (< v0.18)))
-  (ppx_sexp_conv
+  (sexplib0
    (and
     (>= v0.17)
-    (< v0.18)))
-  (ppx_sexp_value
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppxlib
-   (>= 0.33))))
+    (< v0.18)))))
 
 (package
  (name provider-test)

--- a/provider.opam
+++ b/provider.opam
@@ -11,7 +11,6 @@ bug-reports: "https://github.com/mbarbin/provider/issues"
 depends: [
   "dune" {>= "3.16"}
   "ocaml" {>= "5.2"}
-  "base" {>= "v0.17" & < "v0.18"}
   "bisect_ppx" {dev & >= "2.8.3"}
   "ppx_js_style" {dev & >= "v0.17" & < "v0.18"}
   "sexplib0" {>= "v0.17" & < "v0.18"}

--- a/provider.opam
+++ b/provider.opam
@@ -13,12 +13,8 @@ depends: [
   "ocaml" {>= "5.2"}
   "base" {>= "v0.17" & < "v0.18"}
   "bisect_ppx" {dev & >= "2.8.3"}
-  "ppx_compare" {>= "v0.17" & < "v0.18"}
-  "ppx_hash" {>= "v0.17" & < "v0.18"}
   "ppx_js_style" {dev & >= "v0.17" & < "v0.18"}
-  "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
-  "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
-  "ppxlib" {>= "0.33"}
+  "sexplib0" {>= "v0.17" & < "v0.18"}
   "odoc" {with-doc}
 ]
 build: [

--- a/src/dune
+++ b/src/dune
@@ -7,10 +7,4 @@
   (backend bisect_ppx))
  (lint
   (pps ppx_js_style -check-doc-comments))
- (preprocess
-  (pps
-   -unused-code-warnings=force
-   ppx_compare
-   ppx_hash
-   ppx_sexp_conv
-   ppx_sexp_value)))
+ (preprocess no_preprocessing))

--- a/src/dune
+++ b/src/dune
@@ -1,8 +1,8 @@
 (library
  (name provider)
  (public_name provider)
- (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a -open Base)
- (libraries base)
+ (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a -open Sexplib0)
+ (libraries sexplib0)
  (instrumentation
   (backend bisect_ppx))
  (lint

--- a/src/import.ml
+++ b/src/import.ml
@@ -1,0 +1,23 @@
+let phys_equal = ( == )
+
+module Array = struct
+  include ArrayLabels
+
+  let for_alli =
+    let rec loop t ~f i =
+      if i = length t then true else if f i t.(i) then loop t ~f (i + 1) else false
+    in
+    fun t ~f -> loop t ~f 0
+  ;;
+end
+
+module List = ListLabels
+
+module Ordering = struct
+  type t =
+    | Equal
+    | Less
+    | Greater
+
+  let of_int i = if i < 0 then Less else if i = 0 then Equal else Greater
+end

--- a/src/import.mli
+++ b/src/import.mli
@@ -1,0 +1,20 @@
+val phys_equal : 'a -> 'a -> bool
+
+module Array : sig
+  include module type of ArrayLabels
+
+  val for_alli : 'a array -> f:(int -> 'a -> bool) -> bool
+end
+
+module List : sig
+  include module type of ListLabels
+end
+
+module Ordering : sig
+  type t =
+    | Equal
+    | Less
+    | Greater
+
+  val of_int : int -> t
+end

--- a/src/provider.ml
+++ b/src/provider.ml
@@ -22,7 +22,7 @@ module Trait = struct
 
   module Uid = Int
 
-  let uid t =
+  let uid (t : _ t) =
     Stdlib.Obj.Extension_constructor.id (Stdlib.Obj.Extension_constructor.of_val t)
   ;;
 
@@ -61,7 +61,10 @@ module Interface = struct
     let implementations =
       let table = Hashtbl.create (module Trait.Uid) in
       List.iter implementations ~f:(fun implementation ->
-        Hashtbl.set table ~key:(Trait.uid implementation) ~data:implementation);
+        Hashtbl.set
+          table
+          ~key:(Trait.Implementation.uid implementation)
+          ~data:implementation);
       Hashtbl.data table |> List.sort ~compare:Trait.Implementation.compare_by_uid
     in
     match implementations with

--- a/src/provider.ml
+++ b/src/provider.ml
@@ -29,7 +29,14 @@ module Trait = struct
 
   let info = Stdlib.Obj.Extension_constructor.of_val
 
-  module Uid = Int
+  module Uid = struct
+    type t = int
+
+    let sexp_of_t = Sexplib0.Sexp_conv.sexp_of_int
+    let equal = Int.equal
+    let compare = Int.compare
+    let hash = Int.hash
+  end
 
   let uid (t : _ t) =
     Stdlib.Obj.Extension_constructor.id (Stdlib.Obj.Extension_constructor.of_val t)

--- a/src/provider.ml
+++ b/src/provider.ml
@@ -99,7 +99,7 @@ module Interface = struct
       Array.of_list (hd :: implementations)
   ;;
 
-  let same_trait_uids : type a tags1 tags2. (a, tags1) t -> (a, tags2) t -> bool =
+  let same_trait_uids : type a b tags1 tags2. (a, tags1) t -> (b, tags2) t -> bool =
     fun t1 t2 ->
     (* We skip the cell 0 which contains the cache. *)
     if Array.length t1 <> Array.length t2

--- a/src/provider.ml
+++ b/src/provider.ml
@@ -1,3 +1,5 @@
+open! Import
+
 exception E of Sexp.t
 
 let () =
@@ -87,7 +89,7 @@ module Interface = struct
   let make (type a) (implementations : a Trait.Implementation.t list) : (a, _) t =
     let implementations =
       implementations
-      |> List.stable_sort ~compare:Trait.Implementation.compare_by_uid
+      |> List.stable_sort ~cmp:Trait.Implementation.compare_by_uid
       |> dedup_sorted_keep_last ~cmp:Trait.Implementation.compare_by_uid
     in
     match implementations with
@@ -189,7 +191,7 @@ module Interface = struct
       ~trait
       ~update_cache:true
       ~if_not_found:If_not_found.raise
-      ~if_found:Fn.id
+      ~if_found:Fun.id
   ;;
 
   let lookup_opt t ~trait =
@@ -198,7 +200,7 @@ module Interface = struct
       ~trait
       ~update_cache:true
       ~if_not_found:If_not_found.none
-      ~if_found:Option.return
+      ~if_found:Option.some
   ;;
 
   let implements t ~trait =
@@ -209,7 +211,7 @@ module Interface = struct
       ~trait
       ~update_cache:false
       ~if_not_found:If_not_found.false_
-      ~if_found:(Fn.const true)
+      ~if_found:(Fun.const true)
   ;;
 end
 

--- a/src/provider.mli
+++ b/src/provider.mli
@@ -223,7 +223,7 @@ module Private : sig
   module Interface : sig
     (** [same_trait_uids i1 i2] checks if the traits of two interfaces are the
         same and in the same order. *)
-    val same_trait_uids : ('t, _) Interface.t -> ('t, _) Interface.t -> bool
+    val same_trait_uids : ('t1, _) Interface.t -> ('t2, _) Interface.t -> bool
 
     (** Exported to test the caching strategy. Retains the most recently looked
         up trait. Currently returns [None] for empty interface, and if the

--- a/src/provider.mli
+++ b/src/provider.mli
@@ -61,11 +61,6 @@ module Trait : sig
   (** {1 Indexation} *)
 
   module Uid : sig
-    (** A uid is particularly useful when you need to quickly look up or sort
-        traits, as it provides a consistent and unique way to identify each
-        trait. You can use it to manipulate traits within container
-        structures, making it easier to store, retrieve, and compare traits at
-        runtime. *)
     type t
 
     include Comparable.S with type t := t
@@ -76,7 +71,16 @@ module Trait : sig
     val hash : t -> int
   end
 
+  (** A uid is particularly useful when you need to quickly look up or sort
+      traits, as it provides a consistent and unique way to identify each
+      trait. You can use it to manipulate traits within container structures,
+      making it easier to store, retrieve, and compare traits at runtime.
+
+      Trait uniq ids are computed with [Obj.Extension_constructor.id], applied
+      to the constructors of the variant type {!type:Trait.t}, making them valid
+      only for the lifetime of the running program. *)
   val uid : _ t -> Uid.t
+
   val same : _ t -> _ t -> bool
 
   module Implementation : sig

--- a/src/provider.mli
+++ b/src/provider.mli
@@ -45,7 +45,9 @@ module Trait : sig
         This type provides a way to retrieve and display detailed information
         about a trait, which can be useful for debugging and understanding the
         structure and behavior of the provider system. *)
-    type t [@@deriving sexp_of]
+    type t
+
+    val sexp_of_t : t -> Sexp.t
 
     (** Controls whether the runtime ids are shown or hidden in the sexp built
         by {!val:sexp_of_t}. By default [Fn.const (Sexp.Atom "#id")]. You may
@@ -64,9 +66,14 @@ module Trait : sig
         trait. You can use it to manipulate traits within container
         structures, making it easier to store, retrieve, and compare traits at
         runtime. *)
-    type t [@@deriving compare, equal, hash, sexp_of]
+    type t
 
     include Comparable.S with type t := t
+
+    val sexp_of_t : t -> Sexp.t
+    val equal : t -> t -> bool
+    val compare : t -> t -> int
+    val hash : t -> int
   end
 
   val uid : _ t -> Uid.t

--- a/src/provider.mli
+++ b/src/provider.mli
@@ -61,9 +61,7 @@ module Trait : sig
   (** {1 Indexation} *)
 
   module Uid : sig
-    type t
-
-    include Comparable.S with type t := t
+    type t = private int
 
     val sexp_of_t : t -> Sexp.t
     val equal : t -> t -> bool

--- a/test/test__lookup.ml
+++ b/test/test__lookup.ml
@@ -164,3 +164,39 @@ let%expect_test "sub-interface" =
   [%expect {| true |}];
   ()
 ;;
+
+let provider3 () : _ t =
+  let interface =
+    Provider.Interface.make
+      [ Provider.Trait.implement A ~impl:(module Impls.A)
+      ; Provider.Trait.implement C ~impl:(module Impls.C)
+      ; Provider.Trait.implement E ~impl:(module Impls.E)
+      ; Provider.Trait.implement F ~impl:(module Impls.F)
+      ]
+  in
+  Provider.T { t = (); interface }
+;;
+
+let%expect_test "same_trait_uids" =
+  (* This exercises the test when the interface arrays have the same length,
+     otherwise we skip the actual uid comparison branch. *)
+  let same_trait_uids
+    (Provider.T { t = _; interface = i1 })
+    (Provider.T { t = _; interface = i2 })
+    =
+    print_s [%sexp (Provider.Private.Interface.same_trait_uids i1 i2 : bool)]
+  in
+  let p1 = provider () in
+  let p2 = provider2 () in
+  let p2_bis = provider2 () in
+  let p3 = provider3 () in
+  same_trait_uids p1 p1;
+  [%expect {| true |}];
+  same_trait_uids p1 p2;
+  [%expect {| false |}];
+  same_trait_uids p2 p2_bis;
+  [%expect {| true |}];
+  same_trait_uids p2 p3;
+  [%expect {| false |}];
+  ()
+;;


### PR DESCRIPTION
### Changed

- Reduce `provider` package dependencies - reduce from `base` to `sexplib0`.

### Fixed

- Make sure to select the right most implementation in case of overrides, as per specification.

### Removed

- Removed `Trait.Uid.Comparable.S` as this requires `Base`. Make it compatible with `Comparable.Make (Trait.Uid)` and add tests for this use case.
