### PR TITLE
With dev setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 #           janestreet-bleeding-external: https://github.com/janestreet/opam-repository.git#external-packages
 
       - name: Install dependencies
-        run: opam install . --deps-only --with-doc --with-test
+        run: opam install . --deps-only --with-doc --with-test --with-dev-setup
 
       - name: Build
         run: opam exec -- dune build @all @lint

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ lint:
 
 .PHONY: deps
 deps:
-	opam install . --deps-only --with-doc --with-test
+	opam install . --deps-only --with-doc --with-test --with-dev-setup
 
 .PHONY: doc
 doc:

--- a/dune-project
+++ b/dune-project
@@ -23,13 +23,17 @@
  (depends
   (ocaml
    (>= 5.2))
+  (ocamlformat
+   (and
+    :with-dev-setup
+    (= 0.26.2)))
   (bisect_ppx
    (and
-    :dev
+    :with-dev-setup
     (>= 2.8.3)))
   (ppx_js_style
    (and
-    :dev
+    :with-dev-setup
     (>= v0.17)
     (< v0.18)))
   (sexplib0
@@ -43,13 +47,17 @@
  (depends
   (ocaml
    (>= 5.2))
+  (ocamlformat
+   (and
+    :with-dev-setup
+    (= 0.26.2)))
   (base
    (and
     (>= v0.17)
     (< v0.18)))
   (bisect_ppx
    (and
-    :dev
+    :with-dev-setup
     (>= 2.8.3)))
   (eio
    (>= 1.0))
@@ -85,7 +93,7 @@
     (< v0.18)))
   (ppx_js_style
    (and
-    :dev
+    :with-dev-setup
     (>= v0.17)
     (< v0.18)))
   (ppx_let

--- a/provider-tests.opam
+++ b/provider-tests.opam
@@ -10,8 +10,9 @@ bug-reports: "https://github.com/mbarbin/provider/issues"
 depends: [
   "dune" {>= "3.16"}
   "ocaml" {>= "5.2"}
+  "ocamlformat" {with-dev-setup & = "0.26.2"}
   "base" {>= "v0.17" & < "v0.18"}
-  "bisect_ppx" {dev & >= "2.8.3"}
+  "bisect_ppx" {with-dev-setup & >= "2.8.3"}
   "eio" {>= "1.0"}
   "eio_main" {>= "1.0"}
   "expect_test_helpers_core" {>= "v0.17" & < "v0.18"}
@@ -21,7 +22,7 @@ depends: [
   "ppx_expect" {>= "v0.17" & < "v0.18"}
   "ppx_hash" {>= "v0.17" & < "v0.18"}
   "ppx_here" {>= "v0.17" & < "v0.18"}
-  "ppx_js_style" {dev & >= "v0.17" & < "v0.18"}
+  "ppx_js_style" {with-dev-setup & >= "v0.17" & < "v0.18"}
   "ppx_let" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_value" {>= "v0.17" & < "v0.18"}

--- a/provider.opam
+++ b/provider.opam
@@ -10,8 +10,9 @@ bug-reports: "https://github.com/mbarbin/provider/issues"
 depends: [
   "dune" {>= "3.16"}
   "ocaml" {>= "5.2"}
-  "bisect_ppx" {dev & >= "2.8.3"}
-  "ppx_js_style" {dev & >= "v0.17" & < "v0.18"}
+  "ocamlformat" {with-dev-setup & = "0.26.2"}
+  "bisect_ppx" {with-dev-setup & >= "2.8.3"}
+  "ppx_js_style" {with-dev-setup & >= "v0.17" & < "v0.18"}
   "sexplib0" {>= "v0.17" & < "v0.18"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
- [x] Use opam's `:with-dev-setup` for dev only dependencies (instrumentation, lints, ocamlformat).
- [x] Install dev-setup dependencies in CI