### PR TITLE
Support OCaml 4.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
         os:
           - ubuntu-latest
         ocaml-compiler:
+          - 4.14.x
           - 5.2.x
 
     runs-on: ${{ matrix.os }}
@@ -30,13 +31,19 @@ jobs:
 #           janestreet-bleeding: https://github.com/janestreet/opam-repository.git
 #           janestreet-bleeding-external: https://github.com/janestreet/opam-repository.git#external-packages
 
-      - name: Install dependencies
+      - name: Install dependencies for OCaml 4
+        if: startsWith(matrix.ocaml-compiler, '4.')
+        run: opam install . --deps-only --with-doc --with-dev-setup
+
+      - name: Install dependencies for OCaml 5
+        if: startsWith(matrix.ocaml-compiler, '5.')
         run: opam install . --deps-only --with-doc --with-test --with-dev-setup
 
       - name: Build
         run: opam exec -- dune build @all @lint
 
-      - name: Run tests
+      - name: Run OCaml 5 tests
+        if: startsWith(matrix.ocaml-compiler, '5.')
         run: |
              mkdir $BISECT_DIR
              opam exec -- dune runtest --instrument-with bisect_ppx
@@ -44,7 +51,8 @@ jobs:
           BISECT_DIR: ${{ runner.temp }}/_bisect_ppx_data
           BISECT_FILE: ${{ runner.temp }}/_bisect_ppx_data/data
 
-      - name: Send coverage report to Coveralls
+      - name: Send OCaml 5 coverage report to Coveralls
+        if: startsWith(matrix.ocaml-compiler, '5.')
         run: opam exec -- bisect-ppx-report send-to Coveralls --coverage-path $BISECT_DIR
         env:
           BISECT_DIR: ${{ runner.temp }}/_bisect_ppx_data

--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,7 @@
  (synopsis "Dynamic Dispatch with Traits")
  (depends
   (ocaml
-   (>= 5.2))
+   (>= 4.14))
   (sexplib0
    (and
     (>= v0.17)

--- a/provider.opam
+++ b/provider.opam
@@ -9,7 +9,7 @@ doc: "https://mbarbin.github.io/provider/"
 bug-reports: "https://github.com/mbarbin/provider/issues"
 depends: [
   "dune" {>= "3.16"}
-  "ocaml" {>= "5.2"}
+  "ocaml" {>= "4.14"}
   "sexplib0" {>= "v0.17" & < "v0.18"}
   "odoc" {with-doc}
 ]

--- a/src/dune
+++ b/src/dune
@@ -3,8 +3,19 @@
  (public_name provider)
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a -open Sexplib0)
  (libraries sexplib0)
+ (modules (:standard \ uid4xx uid5xx))
  (instrumentation
   (backend bisect_ppx))
  (lint
   (pps ppx_js_style -check-doc-comments))
  (preprocess no_preprocessing))
+
+(rule
+ (enabled_if (< %{ocaml_version} 5.0))
+ (target selecteduid.ml)
+ (action (copy uid4xx.ml %{target})))
+
+(rule
+ (enabled_if (>= %{ocaml_version} 5.0))
+ (target selecteduid.ml)
+ (action (copy uid5xx.ml %{target})))

--- a/src/provider.ml
+++ b/src/provider.ml
@@ -31,14 +31,7 @@ module Trait = struct
 
   let info = Stdlib.Obj.Extension_constructor.of_val
 
-  module Uid = struct
-    type t = int
-
-    let sexp_of_t = Sexplib0.Sexp_conv.sexp_of_int
-    let equal = Int.equal
-    let compare = Int.compare
-    let hash = Int.hash
-  end
+  module Uid = Selecteduid
 
   let uid (t : _ t) =
     Stdlib.Obj.Extension_constructor.id (Stdlib.Obj.Extension_constructor.of_val t)

--- a/src/selecteduid.mli
+++ b/src/selecteduid.mli
@@ -1,0 +1,5 @@
+type t = int
+val sexp_of_t : t -> Sexp.t
+val equal : t -> t -> bool
+val compare : t -> t -> int
+val hash : t -> int

--- a/src/uid4xx.ml
+++ b/src/uid4xx.ml
@@ -1,0 +1,6 @@
+type t = int
+
+let sexp_of_t = Sexplib0.Sexp_conv.sexp_of_int
+let equal = Int.equal
+let compare = Int.compare
+let hash : t -> int = Hashtbl.hash

--- a/src/uid5xx.ml
+++ b/src/uid5xx.ml
@@ -1,0 +1,6 @@
+type t = int
+
+let sexp_of_t = Sexplib0.Sexp_conv.sexp_of_int
+let equal = Int.equal
+let compare = Int.compare
+let hash = Int.hash


### PR DESCRIPTION
Currently the `provider` library supports OCaml 4, except for a minor use of `Int.hash` introduced in 5.1. The `provider-tests` library, since it is tied to Jane Street libraries, depends on OCaml 5.2.

This PR drops the requirement for `provider` down to OCaml 4.14. It can probably go much lower, but 4.14 is the LTS version. (And I haven't decided whether I'm going to use it yet ... but couldn't test it until it worked on OCaml 4).

This PR provides differing OCaml 4 and OCaml 5 implementations of `Uid` ... the OCaml 5 version uses `Int.hash` while OCaml 4 uses the (slightly slower) polymorphic `Hashtbl.hash`. There should be no difference in functionality+performance for OCaml 5.