### PR TITLE
Validate traits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 ### Changed
 
+- Make the library detect invalid Traits earlier (during handler creation) (#20, @mbarbin).
 - Rename `explanation` section of documentation per diataxis.
 
 ### Deprecated

--- a/src/provider.ml
+++ b/src/provider.ml
@@ -47,7 +47,20 @@ module Trait = struct
   let uid (t : _ t) = Obj.Extension_constructor.id (extension_constructor t)
   let compare_by_uid id1 id2 = Uid.compare (uid id1) (uid id2)
   let same (id1 : _ t) (id2 : _ t) = phys_same id1 id2
-  let implement = Binding0.implement
+
+  let check_trait_exn (t : _ t) =
+    if not (Trait0.is_valid t)
+    then
+      raise_s
+        "Invalid usage of [Provider.Trait]: trait is not a valid extensible variant for \
+         this library"
+        (Sexp.List [ List [ Atom "trait"; info t |> Info.sexp_of_t ] ])
+  ;;
+
+  let implement trait ~impl =
+    check_trait_exn trait;
+    Binding0.implement trait ~impl
+  ;;
 
   module Unsafe_cast : sig
     type (_, _) eq_opt =
@@ -249,5 +262,13 @@ type -'tags t =
 
 module Private = struct
   module Import = Import
+
+  module Trait = struct
+    let implement_unsafe trait ~impl ~check_trait =
+      if check_trait then Trait.check_trait_exn trait;
+      Binding0.implement trait ~impl
+    ;;
+  end
+
   module Handler = Handler
 end

--- a/src/provider.mli
+++ b/src/provider.mli
@@ -27,7 +27,11 @@ module Trait : sig
         phantom type designed to make {!val:Handler.lookup} more type-safe.
 
       ['module_type] is expected to be a module type (Eio supports single
-      functions but this is discouraged through the use of this library). *)
+      functions but this is discouraged through the use of this library).
+
+      Beware, traits constructors must be such that they are physically equal
+      when they have the same extension id. In particular they should have zero
+      arguments. *)
   type ('t, 'module_type, 'tag) t = ('t, 'module_type, 'tag) Trait0.t = ..
 
   (** {1 Dump & debug} *)
@@ -233,6 +237,19 @@ module Private : sig
 
     (** Part of the strategy for [make], [extend], etc. *)
     val dedup_sorted_keep_last : 'a list -> compare:('a -> 'a -> int) -> 'a list
+  end
+
+  module Trait : sig
+    (** Some error cases of the implementation have been made non-reachable
+        thanks to additional checks run early. However, we'd like to cover
+        these cases in tests, thus this constructor is exposed to optionally
+        bypass the trait validation happening during [implement]. To be used
+        by tests only, do not use in user code. *)
+    val implement_unsafe
+      :  ('t, 'module_type, _) Trait.t
+      -> impl:'module_type
+      -> check_trait:bool
+      -> 't Binding.t
   end
 
   module Import : sig

--- a/src/trait0.ml
+++ b/src/trait0.ml
@@ -1,1 +1,6 @@
 type ('t, 'module_type, 'tag) t = ..
+
+let is_valid (t : _ t) =
+  let extension_constructor = Obj.Extension_constructor.of_val t in
+  Obj.repr t == Obj.repr extension_constructor
+;;

--- a/src/trait0.mli
+++ b/src/trait0.mli
@@ -1,1 +1,6 @@
 type ('t, 'module_type, 'tag) t = ..
+
+(** Through the use of this library, a tag is only valid if it has no arguments.
+    This function is used to check that, and used to validate traits built by
+    the user to detect invalid usage of the library. *)
+val is_valid : _ t -> bool

--- a/test/test__magic2.ml
+++ b/test/test__magic2.ml
@@ -9,8 +9,8 @@ end
 type (_, _, _) Provider.Trait.t +=
   | A : 'a -> (_, (module S with type t = 'a), [> `A ]) Provider.Trait.t
 
-let impl (type a) arg =
-  Provider.Trait.implement
+let impl (type a) arg ~check_trait =
+  Provider.Private.Trait.implement_unsafe
     (A arg)
     ~impl:
       (module struct
@@ -18,12 +18,24 @@ let impl (type a) arg =
 
         let t = arg
       end)
+    ~check_trait
 ;;
 
 let%expect_test "magic" =
-  let handler =
-    Provider.Handler.make [ (if true then impl 1 else impl "" [@coverage off]) ]
+  let make_handler ~check_trait =
+    Provider.Handler.make
+      [ (if true then impl 1 ~check_trait else impl "" ~check_trait [@coverage off]) ]
   in
+  require_does_raise [%here] (fun () -> make_handler ~check_trait:true);
+  [%expect
+    {|
+    ("Invalid usage of [Provider.Trait]: trait is not a valid extensible variant for this library"
+     ((
+       trait (
+         (id   #id)
+         (name Provider_test.Test__magic2.A)))))
+    |}];
+  let handler = make_handler ~check_trait:false in
   require_does_raise [%here] (fun () ->
     (let module M = (val Provider.Handler.lookup handler ~trait:(A "0")) in
     print_string M.t) [@coverage off]);


### PR DESCRIPTION
Make the library detect invalid Traits earlier (during handler creation).

With this change, invalid usage will be detected during the creation of a handler (`Provider.Trait.implement`), making it impossible to construct handlers that contain invalid tags.

This should help detect programming errors earlier in the dependency chain of a project.

No user facing change for usage that is already correct.