### PR TITLE
Make the library build with 4.14

### DIFF
--- a/.github/workflows/more-ci.yml
+++ b/.github/workflows/more-ci.yml
@@ -30,6 +30,7 @@ jobs:
           - windows-latest
         ocaml-compiler:
           - 5.2.x
+          - 4.14.x
         exclude:
           # We exclude the combination already tested in the 'ci' workflow.
           - os: ubuntu-latest

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- Make the library build with `ocaml.4.14` (#22, @jonahbeckford, @mbarbin).
 - Added new checks in CI (build checks on windows and macos) (#21, @mbarbin).
 - Added a tutorial with new examples of handler-based polymorphism (#13, @mbarbin).
 

--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,7 @@
  (synopsis "Dynamic Dispatch with Traits")
  (depends
   (ocaml
-   (>= 5.2))
+   (>= 4.14))
   (sexplib0
    (and
     (>= v0.17)

--- a/provider.opam
+++ b/provider.opam
@@ -9,7 +9,7 @@ doc: "https://mbarbin.github.io/provider/"
 bug-reports: "https://github.com/mbarbin/provider/issues"
 depends: [
   "dune" {>= "3.16"}
-  "ocaml" {>= "5.2"}
+  "ocaml" {>= "4.14"}
   "sexplib0" {>= "v0.17" & < "v0.18"}
   "odoc" {with-doc}
 ]

--- a/src/import.ml
+++ b/src/import.ml
@@ -11,6 +11,12 @@ module Array = struct
   ;;
 end
 
+module Int = struct
+  include Int
+
+  let hash = (Hashtbl.hash : int -> int)
+end
+
 module List = struct
   include ListLabels
 

--- a/src/import.mli
+++ b/src/import.mli
@@ -6,6 +6,14 @@ module Array : sig
   val for_alli : 'a array -> f:(int -> 'a -> bool) -> bool
 end
 
+module Int : sig
+  include module type of Int
+
+  (** We re-export hash functions here to make the code compatible with earlier
+      ocaml versions. [Stdlib.Int.hash] is available since [ocaml.5.1]. *)
+  val hash : int -> int
+end
+
 module List : sig
   include module type of ListLabels
 


### PR DESCRIPTION
This makes `provider.opam` build with `ocaml.4.14`.

:warning: Currently no tests are run with this version, this is left as future work (see #23).

Special mention to @jonahbeckford for suggesting to build with `4.14`, and who contributed and discussed an earlier version of this change in #14. Thank you!